### PR TITLE
basic chat screen

### DIFF
--- a/App.js
+++ b/App.js
@@ -4,6 +4,7 @@ import { NavigationContainer } from '@react-navigation/native';
 import LoginScreen from './src/screens/LoginScreen';
 import RegistrationScreen from './src/screens/RegistrationScreen';
 import HomeScreen from './src/screens/HomeScreen';
+import Chat from './src/screens/Chat';
 
 const Stack = createNativeStackNavigator();
 
@@ -11,30 +12,31 @@ export default function App() {
   return (
     <NavigationContainer>
       <Stack.Navigator>
+
         <Stack.Screen
-
           name="HomeScreen"
-
-
           component={HomeScreen}
           options={{ headerShown: false }}
         />
 
         <Stack.Screen
-
           name="LoginScreen"
-
           component={LoginScreen}
           options={{ headerShown: false }}
         />
 
         <Stack.Screen
-
           name="RegistrationScreen"
-
           component={RegistrationScreen}
           options={{ headerShown: false }}
+          />
+
+      	<Stack.Screen
+          name='Chat'
+          component={Chat}
+          options={{ headerShown: false }}
         />
+
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/firebase.js
+++ b/firebase.js
@@ -25,4 +25,4 @@ if (firebase.apps.length === 0) {
 const auth = firebase.auth();
 const db = app.firestore();
 
-export { app, auth, db };
+export { firebase ,app, auth, db };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "firebase": "^9.14.0",
         "react": "18.1.0",
         "react-native": "0.70.5",
+        "react-native-gifted-chat": "^1.0.4",
         "react-native-safe-area-context": "4.4.1",
         "react-native-screens": "~3.18.0"
       },
@@ -2732,6 +2733,18 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@expo/react-native-action-sheet": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@expo/react-native-action-sheet/-/react-native-action-sheet-3.13.0.tgz",
+      "integrity": "sha512-EFLK35TBsM28W43SY54lISAIvjEm9584LIRWXsYaf5sgmfF65oWAOQP4UyKxMPLYGoaKjnCAJVFNtZUK80ss9A==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
     "node_modules/@expo/rudder-sdk-node": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@expo/rudder-sdk-node/-/rudder-sdk-node-1.1.1.tgz",
@@ -5222,6 +5235,15 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
       "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA=="
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -5252,6 +5274,26 @@
       "version": "18.11.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
       "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+    },
+    "node_modules/@types/react": {
+      "version": "18.0.25",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.25.tgz",
+      "integrity": "sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "node_modules/@types/yargs": {
       "version": "15.0.14",
@@ -6543,6 +6585,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/dag-map": {
       "version": "1.0.2",
@@ -7889,6 +7936,19 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hosted-git-info": {
       "version": "3.0.8",
@@ -10772,6 +10832,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
     "node_modules/protobufjs": {
       "version": "6.11.3",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
@@ -11014,10 +11089,95 @@
         "nullthrows": "^1.1.1"
       }
     },
+    "node_modules/react-native-communications": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-native-communications/-/react-native-communications-2.2.1.tgz",
+      "integrity": "sha512-5+C0X9mopI0+qxyQHzOPEi5v5rxNBQjxydPPiKMQSlX1RBIcJ8uTcqUPssQ9Mo8p6c1IKIWJUSqCj4jAmD0qVQ=="
+    },
+    "node_modules/react-native-gifted-chat": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/react-native-gifted-chat/-/react-native-gifted-chat-1.0.4.tgz",
+      "integrity": "sha512-MN6W69trS3zzTRZ0US9z2P7YLcKSDw5TGW8qR8Sb7Ytrc0AhGUvdryl3VecRWAPyWwc6aqtA+Vkgb/XWHShoSQ==",
+      "dependencies": {
+        "@expo/react-native-action-sheet": "3.13.0",
+        "dayjs": "1.8.26",
+        "prop-types": "15.7.2",
+        "react-native-communications": "2.2.1",
+        "react-native-iphone-x-helper": "1.3.1",
+        "react-native-lightbox-v2": "0.9.0",
+        "react-native-parsed-text": "0.0.22",
+        "react-native-safe-area-context": "^4.2.4",
+        "react-native-typing-animation": "0.1.7",
+        "use-memo-one": "1.1.2",
+        "uuid": "3.4.0"
+      },
+      "peerDependencies": {
+        "@expo/react-native-action-sheet": "*",
+        "dayjs": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-communications": "*",
+        "react-native-lightbox": "*",
+        "react-native-parsed-text": "*",
+        "react-native-safe-area-context": "*",
+        "react-native-typing-animation": "*"
+      }
+    },
+    "node_modules/react-native-gifted-chat/node_modules/dayjs": {
+      "version": "1.8.26",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.26.tgz",
+      "integrity": "sha512-KqtAuIfdNfZR5sJY1Dixr2Is4ZvcCqhb0dZpCOt5dGEFiMzoIbjkTSzUb4QKTCsP+WNpGwUjAFIZrnZvUxxkhw=="
+    },
+    "node_modules/react-native-gifted-chat/node_modules/use-memo-one": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
+      "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
+      }
+    },
     "node_modules/react-native-gradle-plugin": {
       "version": "0.70.3",
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.70.3.tgz",
       "integrity": "sha512-oOanj84fJEXUg9FoEAQomA8ISG+DVIrTZ3qF7m69VQUJyOGYyDZmPqKcjvRku4KXlEH6hWO9i4ACLzNBh8gC0A=="
+    },
+    "node_modules/react-native-iphone-x-helper": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz",
+      "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==",
+      "peerDependencies": {
+        "react-native": ">=0.42.0"
+      }
+    },
+    "node_modules/react-native-lightbox": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/react-native-lightbox/-/react-native-lightbox-0.8.1.tgz",
+      "integrity": "sha512-TFZA6iKEEHpAUIXjMTRb6vx0/9rHgEKy3ZBiRAy295PwldYg5c8opwnbyURLIl522ykeqhVx9uGdXjSMIowLvA==",
+      "peer": true,
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      }
+    },
+    "node_modules/react-native-lightbox-v2": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/react-native-lightbox-v2/-/react-native-lightbox-v2-0.9.0.tgz",
+      "integrity": "sha512-Fc5VFHFj2vokS+OegyTsANKb1CYoUlOtAv+EBH5wtpJn1b5cey6jVXH7136G5+8OC9JmKWSgKHc5thFwOoZTUg==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-native": ">=0.61.0"
+      }
+    },
+    "node_modules/react-native-parsed-text": {
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/react-native-parsed-text/-/react-native-parsed-text-0.0.22.tgz",
+      "integrity": "sha512-hfD83RDXZf9Fvth3DowR7j65fMnlqM9PpxZBGWkzVcUTFtqe6/yPcIoIAgrJbKn6YmtzkivmhWE2MCE4JKBXrQ==",
+      "dependencies": {
+        "prop-types": "^15.7.x"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/react-native-safe-area-context": {
       "version": "4.4.1",
@@ -11037,6 +11197,16 @@
         "warn-once": "^0.1.0"
       },
       "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-typing-animation": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/react-native-typing-animation/-/react-native-typing-animation-0.1.7.tgz",
+      "integrity": "sha512-4H3rF9M+I2yAZpYJcY0Mb29TXkn98QK12rrKSY6LZj1BQD9NNmRZuNXzwX4XHapsIz+N/J8M3p27FOQPbfzqeg==",
+      "peerDependencies": {
+        "prop-types": "*",
         "react": "*",
         "react-native": "*"
       }
@@ -15233,6 +15403,15 @@
         }
       }
     },
+    "@expo/react-native-action-sheet": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@expo/react-native-action-sheet/-/react-native-action-sheet-3.13.0.tgz",
+      "integrity": "sha512-EFLK35TBsM28W43SY54lISAIvjEm9584LIRWXsYaf5sgmfF65oWAOQP4UyKxMPLYGoaKjnCAJVFNtZUK80ss9A==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@expo/rudder-sdk-node": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@expo/rudder-sdk-node/-/rudder-sdk-node-1.1.1.tgz",
@@ -17170,6 +17349,15 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
       "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA=="
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -17200,6 +17388,26 @@
       "version": "18.11.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
       "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+    },
+    "@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+    },
+    "@types/react": {
+      "version": "18.0.25",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.25.tgz",
+      "integrity": "sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==",
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/yargs": {
       "version": "15.0.14",
@@ -18204,6 +18412,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
+    },
+    "csstype": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "dag-map": {
       "version": "1.0.2",
@@ -19240,6 +19453,21 @@
       "integrity": "sha512-cnN7bQUm65UWOy6cbGcCcZ3rpwW8Q/j4OP5aWRhEry4Z2t2aR1cjrbp0BS+KiBN0smvP1caBgAuxutvyvJILzQ==",
       "requires": {
         "source-map": "^0.7.3"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
       }
     },
     "hosted-git-info": {
@@ -21448,6 +21676,23 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
     "protobufjs": {
       "version": "6.11.3",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
@@ -21636,10 +21881,75 @@
         "nullthrows": "^1.1.1"
       }
     },
+    "react-native-communications": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-native-communications/-/react-native-communications-2.2.1.tgz",
+      "integrity": "sha512-5+C0X9mopI0+qxyQHzOPEi5v5rxNBQjxydPPiKMQSlX1RBIcJ8uTcqUPssQ9Mo8p6c1IKIWJUSqCj4jAmD0qVQ=="
+    },
+    "react-native-gifted-chat": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/react-native-gifted-chat/-/react-native-gifted-chat-1.0.4.tgz",
+      "integrity": "sha512-MN6W69trS3zzTRZ0US9z2P7YLcKSDw5TGW8qR8Sb7Ytrc0AhGUvdryl3VecRWAPyWwc6aqtA+Vkgb/XWHShoSQ==",
+      "requires": {
+        "@expo/react-native-action-sheet": "3.13.0",
+        "dayjs": "1.8.26",
+        "prop-types": "15.7.2",
+        "react-native-communications": "2.2.1",
+        "react-native-iphone-x-helper": "1.3.1",
+        "react-native-lightbox-v2": "0.9.0",
+        "react-native-parsed-text": "0.0.22",
+        "react-native-safe-area-context": "^4.2.4",
+        "react-native-typing-animation": "0.1.7",
+        "use-memo-one": "1.1.2",
+        "uuid": "3.4.0"
+      },
+      "dependencies": {
+        "dayjs": {
+          "version": "1.8.26",
+          "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.26.tgz",
+          "integrity": "sha512-KqtAuIfdNfZR5sJY1Dixr2Is4ZvcCqhb0dZpCOt5dGEFiMzoIbjkTSzUb4QKTCsP+WNpGwUjAFIZrnZvUxxkhw=="
+        },
+        "use-memo-one": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
+          "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==",
+          "requires": {}
+        }
+      }
+    },
     "react-native-gradle-plugin": {
       "version": "0.70.3",
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.70.3.tgz",
       "integrity": "sha512-oOanj84fJEXUg9FoEAQomA8ISG+DVIrTZ3qF7m69VQUJyOGYyDZmPqKcjvRku4KXlEH6hWO9i4ACLzNBh8gC0A=="
+    },
+    "react-native-iphone-x-helper": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz",
+      "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==",
+      "requires": {}
+    },
+    "react-native-lightbox": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/react-native-lightbox/-/react-native-lightbox-0.8.1.tgz",
+      "integrity": "sha512-TFZA6iKEEHpAUIXjMTRb6vx0/9rHgEKy3ZBiRAy295PwldYg5c8opwnbyURLIl522ykeqhVx9uGdXjSMIowLvA==",
+      "peer": true,
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
+    "react-native-lightbox-v2": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/react-native-lightbox-v2/-/react-native-lightbox-v2-0.9.0.tgz",
+      "integrity": "sha512-Fc5VFHFj2vokS+OegyTsANKb1CYoUlOtAv+EBH5wtpJn1b5cey6jVXH7136G5+8OC9JmKWSgKHc5thFwOoZTUg==",
+      "requires": {}
+    },
+    "react-native-parsed-text": {
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/react-native-parsed-text/-/react-native-parsed-text-0.0.22.tgz",
+      "integrity": "sha512-hfD83RDXZf9Fvth3DowR7j65fMnlqM9PpxZBGWkzVcUTFtqe6/yPcIoIAgrJbKn6YmtzkivmhWE2MCE4JKBXrQ==",
+      "requires": {
+        "prop-types": "^15.7.x"
+      }
     },
     "react-native-safe-area-context": {
       "version": "4.4.1",
@@ -21655,6 +21965,12 @@
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
       }
+    },
+    "react-native-typing-animation": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/react-native-typing-animation/-/react-native-typing-animation-0.1.7.tgz",
+      "integrity": "sha512-4H3rF9M+I2yAZpYJcY0Mb29TXkn98QK12rrKSY6LZj1BQD9NNmRZuNXzwX4XHapsIz+N/J8M3p27FOQPbfzqeg==",
+      "requires": {}
     },
     "react-refresh": {
       "version": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "firebase": "^9.14.0",
     "react": "18.1.0",
     "react-native": "0.70.5",
+    "react-native-gifted-chat": "^1.0.4",
     "react-native-safe-area-context": "4.4.1",
     "react-native-screens": "~3.18.0"
   },

--- a/src/screens/Chat.js
+++ b/src/screens/Chat.js
@@ -1,0 +1,97 @@
+
+import React, {
+    useState,
+    useEffect,
+    useLayoutEffect,
+    useCallback
+} from 'react';
+
+import { StyleSheet, TouchableOpacity, Text,  View , ScrollView , Button } from 'react-native';
+import { GiftedChat } from 'react-native-gifted-chat';
+import { collection ,getDocs, doc ,addDoc , orderBy , query , onSnapshot , setDoc , snapshotEqual} from 'firebase/firestore';
+import { firebase , auth , db} from "../../firebase";
+import { getAuth, signInWithEmailAndPassword } from "firebase/auth";
+
+const Chat = ({navigation}) => {
+    const [messages, setMessages] = useState([]);   
+    const [refresh, setRefresh] = useState(false);   
+    
+    const onSignOut = () => {
+	signOut(auth).catch(error => console.log('Error logging out: ', error));
+    };
+
+    useLayoutEffect(() => {
+	navigation.setOptions({
+	    headerRight: () => (
+		<TouchableOpacity
+		    style={{
+			marginRight: 10
+		    }}
+		    onPress={onSignOut}
+		>
+		    <Text>Logout</Text>
+		</TouchableOpacity>
+	    )
+	});
+    }, [navigation]);
+
+    useEffect(() => {
+	if (!(auth?.currentUser?.email)){
+	    setTimeout( () => {
+		setRefresh(!refresh);
+	    } , 1000);
+	}
+    }, [refresh]);
+   
+    useEffect(() => {
+	const collectionRef = collection(db, 'chats');
+	const q = query(collectionRef, orderBy('createdAt', 'desc'));
+
+	const unsubscribe = onSnapshot(q, querySnapshot => {
+	    setMessages(
+		querySnapshot.docs.map(doc => ({
+		    _id: doc.data()._id,
+		    createdAt: doc.data().createdAt.toDate(),
+		    text: doc.data().text,
+		    user: doc.data().user
+		}))
+	    );
+	});
+
+	return () => unsubscribe();
+    }, []);
+
+
+    const onSend = useCallback((messages = []) => {
+	setMessages(previousMessages =>
+	    GiftedChat.append(previousMessages, messages)
+	);
+	const { _id, createdAt, text, user } = messages[0];    
+	var myCreatedAt = firebase.firestore.Timestamp.fromDate(new Date());
+	addDoc(collection(db, 'chats'), {
+	    _id,
+	    myCreatedAt,
+	    text,
+	    user
+	}).catch( e => {
+		console.log(e);
+	});
+    }, []);
+
+    return (
+	auth?.currentUser?.email  ?
+	     (	
+   	<GiftedChat  messages={messages} showAvatarForEveryMessage={true}
+    onSend={messages => onSend(messages)}
+    user={{  _id: auth?.currentUser?.email,  avatar: 'https://i.pravatar.cc/300' }}
+	/>) :
+	    ( <View style={{ flex: 1 }}><Text>Loading ...</Text></View>
+	    ))
+    
+}
+
+export default Chat;
+
+
+
+

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -17,7 +17,7 @@ const LoginScreen = ({ navigation }) => {
     auth
       .signInWithEmailAndPassword(loginEmail, loginPassword)
       .then((userCredentials) => {
-        navigation.navigate("HomeScreen");
+          navigation.navigate("HomeScreen");
       })
       .catch((err) => alert(err.message));
   };


### PR DESCRIPTION

basic chat screen

user types messages , that appear on firestore backend

it does not seem to pull recent messages from firestore , 
multiple people sending messages may only see their own messages   

originally the chat screen appeared first , bypass login process
so i wrote a hack to login user , this logging-in took a second or two , 

use effect checks to see if current user email is defined , if not then waits a second
before flipping refresh , which is watched by same routine , process repeats so 
keeps refreshing every second until auth has had time to log in user ,
once this is done , refresh is no longer changed , so no more forced refreshes occur.

no errors are being thrown , so i thought that it would be good enough to include 
at this point 

for testing purposes - can change App.js to make loginscreen first in the list , 
then change loginscreen.js to navigate to "Chat" 

